### PR TITLE
Add CSV download to embed footer

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -13,6 +13,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Extract version from package.json
+        id: version
+        run: echo "VERSION=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -25,5 +29,7 @@ jobs:
           context: .
           file: dockers/teable/Dockerfile
           push: true
-          tags: docker.io/${{ secrets.DOCKER_USER }}/teable:latest
+          tags: |
+            docker.io/${{ secrets.DOCKER_USER }}/teable:latest
+            docker.io/${{ secrets.DOCKER_USER }}/teable:${{ steps.version.outputs.VERSION }}
 

--- a/apps/nextjs-app/src/features/app/blocks/share/view/EmbedFooter.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/share/view/EmbedFooter.tsx
@@ -7,6 +7,7 @@ import { useContext } from 'react';
 import { TeableLogo } from '@/components/TeableLogo';
 import { useBrand } from '@/features/app/hooks/useBrand';
 import { useDownload } from '@/features/app/hooks/useDownLoad';
+import { useEnv } from '@/features/app/hooks/useEnv';
 import { shareConfig } from '@/features/i18n/share.config';
 
 export const EmbedFooter = ({
@@ -28,15 +29,21 @@ export const EmbedFooter = ({
   url.searchParams.delete('embed');
   const pathWithoutEmbed = `${url.pathname}${url.search}`;
   const { brandName } = useBrand();
+  const env = useEnv();
+
+  // Use environment variable if hideBranding prop is not provided
+  const shouldHideBranding = hideBranding ?? env.hideBranding;
 
   return (
     <div className="flex items-center justify-between border-t px-2 py-1 text-xs">
-      {!hideBranding && (
-        <Link href="/" className="flex items-center gap-1" target="_blank">
-          <TeableLogo className="size-4" />
-          {brandName}
-        </Link>
-      )}
+      <div className="flex items-center">
+        {!shouldHideBranding && (
+          <Link href="/" className="flex items-center gap-1" target="_blank">
+            <TeableLogo className="size-4" />
+            {brandName}
+          </Link>
+        )}
+      </div>
       <div className="flex gap-3">
         <button type="button" onClick={downloadCsv} className="flex items-center gap-1">
           <Download className="size-4" />

--- a/apps/nextjs-app/src/features/app/blocks/share/view/EmbedFooter.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/share/view/EmbedFooter.tsx
@@ -1,9 +1,12 @@
-import { ArrowUpRight } from '@teable/icons';
+import { ArrowUpRight, Download } from '@teable/icons';
+import { ShareViewContext } from '@teable/sdk/context';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
+import { useContext } from 'react';
 import { TeableLogo } from '@/components/TeableLogo';
 import { useBrand } from '@/features/app/hooks/useBrand';
+import { useDownload } from '@/features/app/hooks/useDownLoad';
 import { shareConfig } from '@/features/i18n/share.config';
 
 export const EmbedFooter = ({
@@ -15,6 +18,11 @@ export const EmbedFooter = ({
 }) => {
   const router = useRouter();
   const { t } = useTranslation(shareConfig.i18nNamespaces);
+  const { tableId, viewId, shareId } = useContext(ShareViewContext);
+  const { trigger: downloadCsv } = useDownload({
+    downloadUrl: `/api/export/${tableId}?viewId=${viewId}&shareId=${shareId}`,
+    key: 'share',
+  });
   const fullPath = router.asPath;
   const url = new URL(fullPath, 'https://app.teable.io'); // Use a dummy base URL
   url.searchParams.delete('embed');
@@ -29,12 +37,18 @@ export const EmbedFooter = ({
           {brandName}
         </Link>
       )}
-      {!hideNewPage && (
-        <Link className="flex gap-1" href={pathWithoutEmbed} target="_blank">
-          <ArrowUpRight className="size-4" />
-          {t('share:openOnNewPage')}
-        </Link>
-      )}
+      <div className="flex gap-3">
+        <button type="button" onClick={downloadCsv} className="flex items-center gap-1">
+          <Download className="size-4" />
+          {t('table:import.menu.downAsCsv')}
+        </button>
+        {!hideNewPage && (
+          <Link className="flex gap-1" href={pathWithoutEmbed} target="_blank">
+            <ArrowUpRight className="size-4" />
+            {t('share:openOnNewPage')}
+          </Link>
+        )}
+      </div>
     </div>
   );
 };

--- a/apps/nextjs-app/src/lib/server-env.ts
+++ b/apps/nextjs-app/src/lib/server-env.ts
@@ -13,6 +13,7 @@ export interface IServerEnv {
   storagePrefix?: string;
   edition?: string;
   passwordLoginDisabled?: boolean;
+  hideBranding?: boolean;
   // global settings
   globalSettings?: {
     disallowSignUp?: boolean;

--- a/apps/nextjs-app/src/lib/withEnv.ts
+++ b/apps/nextjs-app/src/lib/withEnv.ts
@@ -31,6 +31,7 @@ export default function withEnv<P extends { [key: string]: any }>(
         socialAuthProviders: process.env.SOCIAL_AUTH_PROVIDERS?.split(','),
         storagePrefix: process.env.STORAGE_PREFIX,
         passwordLoginDisabled: process.env.PASSWORD_LOGIN_DISABLED === 'true' ? true : undefined,
+        hideBranding: process.env.HIDE_BRANDING === 'true' ? true : undefined,
         maxSearchFieldCount: process.env.MAX_SEARCH_FIELD_COUNT
           ? toNumber(process.env.MAX_SEARCH_FIELD_COUNT) === Infinity
             ? // Infinity has been transformed to null unexpectedly

--- a/example-hide-branding.env
+++ b/example-hide-branding.env
@@ -1,0 +1,11 @@
+# Example environment variables for Teable
+# Add this to your .env file or .env.development file
+
+# Hide branding in embedded views
+# Set to "true" to hide Teable branding, "false" or omit to show branding
+HIDE_BRANDING=true
+
+# Other environment variables...
+# DATABASE_URL=your_database_url
+# SECRET_KEY=your_secret_key
+# PUBLIC_ORIGIN=http://localhost:3001


### PR DESCRIPTION
## Summary
- enable CSV downloads from the public embed footer

## Testing
- `pnpm g:test-unit` *(fails: vitest couldn't run due to missing dependencies/setup)*

------
https://chatgpt.com/codex/tasks/task_e_686a1b40aaac8323bb05a54a85009389