### PR TITLE
Add CSV download to embed footer

### DIFF
--- a/apps/nestjs-backend/src/features/share/share.controller.ts
+++ b/apps/nestjs-backend/src/features/share/share.controller.ts
@@ -59,6 +59,7 @@ import type { IShareViewInfo } from './share-auth.service';
 import { ShareAuthService } from './share-auth.service';
 import { ShareSocketService } from './share-socket.service';
 import { ShareService } from './share.service';
+import { ExportOpenApiService } from '../export/open-api/export-open-api.service';
 
 @Controller('api/share')
 @Public()
@@ -66,7 +67,8 @@ export class ShareController {
   constructor(
     private readonly shareService: ShareService,
     private readonly shareAuthService: ShareAuthService,
-    private readonly shareSocketService: ShareSocketService
+    private readonly shareSocketService: ShareSocketService,
+    private readonly exportOpenApiService: ExportOpenApiService
   ) {}
 
   @HttpCode(200)
@@ -110,6 +112,17 @@ export class ShareController {
   ): Promise<IRowCountVo> {
     const shareInfo = req.shareInfo as IShareViewInfo;
     return this.shareService.getViewRowCount(shareInfo, query);
+  }
+
+  @UseGuards(ShareAuthGuard)
+  @Get('/:shareId/export')
+  async exportCsv(
+    @Request() req: any,
+    @Query('viewId') viewId: string,
+    @Res({ passthrough: true }) res: Response
+  ) {
+    const shareInfo = req.shareInfo as IShareViewInfo;
+    return this.exportOpenApiService.exportCsvFromTable(res, shareInfo.tableId, viewId);
   }
 
   @ShareSubmit()

--- a/apps/nestjs-backend/src/features/share/share.module.ts
+++ b/apps/nestjs-backend/src/features/share/share.module.ts
@@ -8,6 +8,7 @@ import { RecordOpenApiModule } from '../record/open-api/record-open-api.module';
 import { RecordModule } from '../record/record.module';
 import { SelectionModule } from '../selection/selection.module';
 import { ViewModule } from '../view/view.module';
+import { ExportOpenApiModule } from '../export/open-api/export-open-api.module';
 import { ShareAuthModule } from './share-auth.module';
 import { ShareSocketService } from './share-socket.service';
 import { ShareController } from './share.controller';
@@ -24,6 +25,7 @@ import { ShareService } from './share.service';
     ShareAuthModule,
     CollaboratorModule,
     ViewModule,
+    ExportOpenApiModule,
   ],
   providers: [ShareService, DbProvider, ShareSocketService],
   controllers: [ShareController],

--- a/apps/nextjs-app/src/features/app/blocks/share/view/EmbedFooter.tsx
+++ b/apps/nextjs-app/src/features/app/blocks/share/view/EmbedFooter.tsx
@@ -1,9 +1,12 @@
-import { ArrowUpRight } from '@teable/icons';
+import { ArrowUpRight, Download } from '@teable/icons';
+import { ShareViewContext } from '@teable/sdk/context';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { useTranslation } from 'next-i18next';
+import { useContext } from 'react';
 import { TeableLogo } from '@/components/TeableLogo';
 import { useBrand } from '@/features/app/hooks/useBrand';
+import { useDownload } from '@/features/app/hooks/useDownLoad';
 import { shareConfig } from '@/features/i18n/share.config';
 
 export const EmbedFooter = ({
@@ -15,6 +18,11 @@ export const EmbedFooter = ({
 }) => {
   const router = useRouter();
   const { t } = useTranslation(shareConfig.i18nNamespaces);
+  const { viewId, shareId } = useContext(ShareViewContext);
+  const { trigger: downloadCsv } = useDownload({
+    downloadUrl: `/api/share/${shareId}/export?viewId=${viewId}`,
+    key: 'share',
+  });
   const fullPath = router.asPath;
   const url = new URL(fullPath, 'https://app.teable.io'); // Use a dummy base URL
   url.searchParams.delete('embed');
@@ -29,12 +37,18 @@ export const EmbedFooter = ({
           {brandName}
         </Link>
       )}
-      {!hideNewPage && (
-        <Link className="flex gap-1" href={pathWithoutEmbed} target="_blank">
-          <ArrowUpRight className="size-4" />
-          {t('share:openOnNewPage')}
-        </Link>
-      )}
+      <div className="flex gap-3">
+        <button type="button" onClick={downloadCsv} className="flex items-center gap-1">
+          <Download className="size-4" />
+          {t('table:import.menu.downAsCsv')}
+        </button>
+        {!hideNewPage && (
+          <Link className="flex gap-1" href={pathWithoutEmbed} target="_blank">
+            <ArrowUpRight className="size-4" />
+            {t('share:openOnNewPage')}
+          </Link>
+        )}
+      </div>
     </div>
   );
 };

--- a/packages/openapi/src/share/index.ts
+++ b/packages/openapi/src/share/index.ts
@@ -10,3 +10,4 @@ export * from './view-collaborators';
 export * from './view-search-count';
 export * from './view-search-index';
 export * from './view-calendar-daily-collection';
+export * from './view-export';

--- a/packages/openapi/src/share/view-export.ts
+++ b/packages/openapi/src/share/view-export.ts
@@ -1,0 +1,32 @@
+import type { RouteConfig } from '@asteasolutions/zod-to-openapi';
+import { axios } from '../axios';
+import { registerRoute, urlBuilder } from '../utils';
+import { z } from '../zod';
+
+export const SHARE_VIEW_EXPORT = '/share/{shareId}/export';
+
+export const ShareViewExportRoute: RouteConfig = registerRoute({
+  method: 'get',
+  path: SHARE_VIEW_EXPORT,
+  description: 'export share view records as csv',
+  request: {
+    params: z.object({
+      shareId: z.string(),
+    }),
+    query: z.object({
+      viewId: z.string().optional(),
+    }),
+  },
+  responses: {
+    200: {
+      description: 'csv content',
+    },
+  },
+  tags: ['share'],
+});
+
+export const exportShareViewCsv = async (shareId: string, viewId?: string) => {
+  return axios.get(urlBuilder(SHARE_VIEW_EXPORT, { shareId }), {
+    params: { viewId },
+  });
+};


### PR DESCRIPTION
## Summary
- enable CSV downloads from public embeds via new `/api/share/{shareId}/export` endpoint
- expose the new API via OpenAPI utilities
- hook the embed footer download button to the share export API

## Testing
- `pnpm g:test-unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a1b40aaac8323bb05a54a85009389